### PR TITLE
[MAPA-71] fix: updates support_request before creating match

### DIFF
--- a/src/match/createMatch.ts
+++ b/src/match/createMatch.ts
@@ -19,6 +19,20 @@ export async function createMatch(
     volunteerAvailability["volunteer_id"]
   );
 
+  await client.supportRequests.update({
+    where: {
+      supportRequestId: supportRequest.supportRequestId,
+    },
+    data: {
+      status: "matched",
+      SupportRequestStatusHistory: {
+        create: {
+          status: "matched",
+        },
+      },
+    },
+  });
+
   const match = await client.matches.create({
     data: {
       supportRequestId: supportRequest.supportRequestId,
@@ -33,20 +47,6 @@ export async function createMatch(
       MatchStatusHistory: {
         create: {
           status: "waiting_contact",
-        },
-      },
-    },
-  });
-
-  await client.supportRequests.update({
-    where: {
-      supportRequestId: supportRequest.supportRequestId,
-    },
-    data: {
-      status: "matched",
-      SupportRequestStatusHistory: {
-        create: {
-          status: "matched",
         },
       },
     },


### PR DESCRIPTION
Esse PR apenas garante que o support_request seja atualizado antes de criarmos o match. Isso é importante para que a ordem dos eventos na jornada da MSR faça sentido.