### PR TITLE
[MAPA-681] fix: update volunteer status after match

### DIFF
--- a/src/match/__tests__/createMatch.spec.ts
+++ b/src/match/__tests__/createMatch.spec.ts
@@ -1,27 +1,37 @@
-import { checkVolunteerAvailability } from "../createMatch";
+import type { VolunteerAvailability } from "@prisma/client";
+import { checkUpdateVolunteerStatus } from "../createMatch";
 
-describe("checkVolunteerAvailability()", () => {
-  it("should return false if volunteer is not available after receiving a new match", () => {
-    const currentMatches = 2;
-    const maxMatches = 3;
+const mockVolunteerAvailability = {
+  volunteer_id: 1,
+  current_matches: 1,
+  max_matches: 2,
+  is_available: true,
+} as VolunteerAvailability;
 
-    const isVolunteerAvailable = checkVolunteerAvailability(
-      currentMatches,
-      maxMatches
+describe("checkUpdateVolunteerStatus()", () => {
+  it("should return true if volunteer was previously available and is reaching the max matches", () => {
+    const shouldUpdateVolunteerStatus = checkUpdateVolunteerStatus(
+      mockVolunteerAvailability
     );
 
-    expect(isVolunteerAvailable).toStrictEqual(false);
+    expect(shouldUpdateVolunteerStatus).toStrictEqual(true);
   });
 
-  it("should return true if volunteer is still available after receiving a new match", () => {
-    const currentMatches = 1;
-    const maxMatches = 3;
+  it("should return false if volunteer was previously available but is not reaching the max matches", () => {
+    const shouldUpdateVolunteerStatus = checkUpdateVolunteerStatus({
+      ...mockVolunteerAvailability,
+      max_matches: 3,
+    });
 
-    const isVolunteerAvailable = checkVolunteerAvailability(
-      currentMatches,
-      maxMatches
-    );
+    expect(shouldUpdateVolunteerStatus).toStrictEqual(false);
+  });
 
-    expect(isVolunteerAvailable).toStrictEqual(true);
+  it("should return false if volunteer was not previously available", () => {
+    const shouldUpdateVolunteerStatus = checkUpdateVolunteerStatus({
+      ...mockVolunteerAvailability,
+      is_available: false,
+    });
+
+    expect(shouldUpdateVolunteerStatus).toStrictEqual(false);
   });
 });

--- a/src/match/__tests__/updateUnavailableVolunteer.spec.ts
+++ b/src/match/__tests__/updateUnavailableVolunteer.spec.ts
@@ -1,4 +1,4 @@
-import type { Volunteers } from "@prisma/client";
+import type { VolunteerAvailability, Volunteers } from "@prisma/client";
 import * as zendeskClient from "../../zendeskClient";
 import { prismaMock } from "../../setupTests";
 import updateUnavailableVolunteer from "../updateUnavailableVolunteer";
@@ -20,11 +20,17 @@ const mockVolunteerFromZendesk = {
     condition: "indisponivel_sem_vagas",
   },
 } as ZendeskUser;
+const mockVolunteerAvailability = {
+  volunteer_id: 1,
+} as VolunteerAvailability;
 
 describe("updateUnavailableVolunteer", () => {
   it("should throw an error if volunteer has null zendesk_ticket_id", async () => {
     prismaMock.volunteers.update.mockResolvedValueOnce(
       mockVolunteerFromDBNullZendeskUserId
+    );
+    prismaMock.volunteerAvailability.update.mockResolvedValueOnce(
+      mockVolunteerAvailability
     );
 
     await expect(updateUnavailableVolunteer(mockVolunteerId)).rejects.toThrow(
@@ -34,6 +40,9 @@ describe("updateUnavailableVolunteer", () => {
 
   it("should throw an error if no volunteer was updated on Zendesk", async () => {
     prismaMock.volunteers.update.mockResolvedValueOnce(mockVolunteerFromDB);
+    prismaMock.volunteerAvailability.update.mockResolvedValueOnce(
+      mockVolunteerAvailability
+    );
     updateUserMock.mockResolvedValueOnce(null);
 
     await expect(updateUnavailableVolunteer(mockVolunteerId)).rejects.toThrow(
@@ -43,6 +52,9 @@ describe("updateUnavailableVolunteer", () => {
 
   it("should call updateUser function with correct payload", async () => {
     prismaMock.volunteers.update.mockResolvedValueOnce(mockVolunteerFromDB);
+    prismaMock.volunteerAvailability.update.mockResolvedValueOnce(
+      mockVolunteerAvailability
+    );
     updateUserMock.mockResolvedValueOnce(mockVolunteerFromZendesk);
     await updateUnavailableVolunteer(mockVolunteerId);
 
@@ -54,6 +66,9 @@ describe("updateUnavailableVolunteer", () => {
 
   it("should update volunteer zendesk status to indisponivel_sem_vagas", async () => {
     prismaMock.volunteers.update.mockResolvedValueOnce(mockVolunteerFromDB);
+    prismaMock.volunteerAvailability.update.mockResolvedValueOnce(
+      mockVolunteerAvailability
+    );
     updateUserMock.mockResolvedValueOnce(mockVolunteerFromZendesk);
 
     const updatedVolunteer = await updateUnavailableVolunteer(mockVolunteerId);

--- a/src/match/updateUnavailableVolunteer.ts
+++ b/src/match/updateUnavailableVolunteer.ts
@@ -15,6 +15,15 @@ export default async function updateUnavailableVolunteer(
     },
   });
 
+  const volunteerAvailability = await client.volunteerAvailability.update({
+    where: {
+      volunteer_id: volunteerId,
+    },
+    data: {
+      is_available: false,
+    },
+  });
+
   await client.volunteerStatusHistory.create({
     data: {
       volunteer_id: volunteerId,
@@ -23,7 +32,7 @@ export default async function updateUnavailableVolunteer(
     },
   });
 
-  if (!volunteer || !volunteer.zendeskUserId)
+  if (!volunteer || !volunteerAvailability || !volunteer.zendeskUserId)
     throw new Error("Couldn't fetch volunteer from db");
 
   const volunteerZendeskUser: Pick<ZendeskUser, "id" | "user_fields"> = {


### PR DESCRIPTION
Esse PR atualiza a função `createMatch`, adicionando um fix na checagem que fazemos para verificar se devemos ou não atualizar o status da voluntária.

Estávamos tendo algumas inconsistência devido a atualização do status para `is_available = true` de voluntárias que estavam previamente indisponíveis.

Agora, com o fix, só vamos fazer essa atualização caso ela esteja com `is_available = true` previamente e esteja atingindo o número máximo de matches (ou seja, deve ficar com status = Indisponível - Sem Vagas).