### PR TITLE
[MAPA-731] Usa encoded_id nos emails para o replyTo

### DIFF
--- a/src/__tests__/process.spec.ts
+++ b/src/__tests__/process.spec.ts
@@ -24,6 +24,7 @@ const getUserMock = jest.spyOn(getUser, "default");
 updateTicketMock.mockImplementation(() =>
   Promise.resolve({
     id: 123123123,
+    encoded_id: "ABC-123",
   } as unknown as ZendeskTicket)
 );
 

--- a/src/emailClient/__tests__/index.spec.ts
+++ b/src/emailClient/__tests__/index.spec.ts
@@ -10,7 +10,7 @@ const sendEmailMock = jest.spyOn(sendEmail, "default");
 const msr = {
   name: "teste msr",
   email: "teste@msr.com",
-  zendeskTicketId: 123123 as unknown as bigint,
+  encoded_id: "ABC-123",
 };
 const volunteer = {
   firstName: "Voluntaria",
@@ -18,7 +18,7 @@ const volunteer = {
   phone: "11911091199",
   registrationNumber: "123123",
   email: "teste@voluntaria.com",
-  zendeskTicketId: 123123 as unknown as bigint,
+  encoded_id: "EFG-456",
 };
 
 describe("sendEmailPublicService", () => {
@@ -26,11 +26,11 @@ describe("sendEmailPublicService", () => {
     sendEmailMock.mockResolvedValueOnce(true);
   });
   it("should call sendEmail with correct params", async () => {
-    const zendeskTicketId = "123123";
+    const encodedId = "ABC-123";
     const res = await sendEmailPublicService(
       "test@msr.com",
       "teste MSR",
-      zendeskTicketId
+      encodedId
     );
     expect(res).toStrictEqual(true);
     expect(sendEmailMock).toHaveBeenNthCalledWith(
@@ -39,7 +39,7 @@ describe("sendEmailPublicService", () => {
       "clv43j25d00b0y19vj7x8qdxy",
       {
         msr_first_name: "Teste",
-        msr_zendesk_ticket_id: zendeskTicketId,
+        msr_zendesk_ticket_id: encodedId,
       }
     );
   });
@@ -50,11 +50,11 @@ describe("sendEmailSocialWorker", () => {
     sendEmailMock.mockResolvedValueOnce(true);
   });
   it("should call sendEmail with correct params", async () => {
-    const zendeskTicketId = "123123";
+    const encodedId = "ABC-123";
     const res = await sendEmailSocialWorker(
       "test@msr.com",
       "teste MSR",
-      zendeskTicketId
+      encodedId
     );
     expect(res).toStrictEqual(true);
     expect(sendEmailMock).toHaveBeenNthCalledWith(
@@ -63,7 +63,7 @@ describe("sendEmailSocialWorker", () => {
       "clv4a8qf1004meoqo89fcfjy7",
       {
         msr_first_name: "Teste",
-        msr_zendesk_ticket_id: zendeskTicketId,
+        msr_zendesk_ticket_id: encodedId,
       }
     );
   });
@@ -91,7 +91,7 @@ describe("sendEmailToMsr", () => {
           volunteer_phone: "11911091199",
           lawyer_phone: "11911091199",
           volunteer_registration_number: "123123",
-          msr_zendesk_ticket_id: msr.zendeskTicketId.toString(),
+          msr_zendesk_ticket_id: msr.encoded_id,
         }
       );
     });
@@ -114,7 +114,7 @@ describe("sendEmailToMsr", () => {
           volunteer_phone: "11911091199",
           lawyer_phone: "11911091199",
           volunteer_registration_number: "123123",
-          msr_zendesk_ticket_id: msr.zendeskTicketId.toString(),
+          msr_zendesk_ticket_id: msr.encoded_id,
         }
       );
     });
@@ -141,7 +141,7 @@ describe("sendEmailToVolunteer", () => {
           volunteer_first_name: "Voluntaria",
           msr_first_name: "Teste",
           volunteer_phone: "11911091199",
-          volunteer_zendesk_ticket_id: volunteer.zendeskTicketId.toString(),
+          volunteer_zendesk_ticket_id: volunteer.encoded_id,
         }
       );
     });
@@ -158,7 +158,7 @@ describe("sendEmailToVolunteer", () => {
           volunteer_first_name: "Voluntaria",
           msr_first_name: "Teste",
           volunteer_phone: "11911091199",
-          volunteer_zendesk_ticket_id: volunteer.zendeskTicketId.toString(),
+          volunteer_zendesk_ticket_id: volunteer.encoded_id,
         }
       );
     });

--- a/src/emailClient/index.ts
+++ b/src/emailClient/index.ts
@@ -24,7 +24,7 @@ export async function sendEmailToMsr(
     // Não consegui remover esse parâmetro do Loops, então preciamos enviar
     lawyer_phone: volunteer.phone,
     volunteer_registration_number: volunteer.registrationNumber,
-    msr_zendesk_ticket_id: msr.encoded_id.toString(),
+    msr_zendesk_ticket_id: msr.encoded_id,
   };
 
   const emailRes = await sendEmail(msr.email, transactionalId, emailVars);
@@ -43,7 +43,7 @@ export async function sendEmailToVolunteer(
     volunteer_first_name: getFirstName(volunteer.firstName),
     msr_first_name: getFirstName(msrFirstName),
     volunteer_phone: volunteer.phone,
-    volunteer_zendesk_ticket_id: volunteer.encoded_id.toString(),
+    volunteer_zendesk_ticket_id: volunteer.encoded_id,
   };
 
   const emailRes = await sendEmail(volunteer.email, id, emailVars);

--- a/src/emailClient/index.ts
+++ b/src/emailClient/index.ts
@@ -10,7 +10,7 @@ type Volunteer = Pick<
 >;
 
 type Msr = Pick<ZendeskUser, "name" | "email"> &
-  Pick<SupportRequest, "zendeskTicketId">;
+  Pick<ZendeskTicket, "encoded_id">;
 
 export async function sendEmailToMsr(
   msr: Msr,
@@ -24,7 +24,7 @@ export async function sendEmailToMsr(
     // Não consegui remover esse parâmetro do Loops, então preciamos enviar
     lawyer_phone: volunteer.phone,
     volunteer_registration_number: volunteer.registrationNumber,
-    msr_zendesk_ticket_id: msr.zendeskTicketId.toString(),
+    msr_zendesk_ticket_id: msr.encoded_id.toString(),
   };
 
   const emailRes = await sendEmail(msr.email, transactionalId, emailVars);
@@ -33,7 +33,7 @@ export async function sendEmailToMsr(
 }
 
 export async function sendEmailToVolunteer(
-  volunteer: Volunteer & { zendeskTicketId: ZendeskTicket["id"] },
+  volunteer: Volunteer & Pick<ZendeskTicket, "encoded_id">,
   msrFirstName: Msr["name"],
   supportType: SupportRequest["supportType"]
 ) {
@@ -43,7 +43,7 @@ export async function sendEmailToVolunteer(
     volunteer_first_name: getFirstName(volunteer.firstName),
     msr_first_name: getFirstName(msrFirstName),
     volunteer_phone: volunteer.phone,
-    volunteer_zendesk_ticket_id: volunteer.zendeskTicketId.toString(),
+    volunteer_zendesk_ticket_id: volunteer.encoded_id.toString(),
   };
 
   const emailRes = await sendEmail(volunteer.email, id, emailVars);

--- a/src/match/__tests__/createAndUpdateZendeskMatchTickets.spec.ts
+++ b/src/match/__tests__/createAndUpdateZendeskMatchTickets.spec.ts
@@ -21,9 +21,11 @@ jest.spyOn(global.Math, "random").mockReturnValue(0.7);
 
 const mockVolunteerZendeskTicket = {
   id: 123123123 as unknown as bigint,
+  encoded_id: "EFG-456",
 } as ZendeskTicket;
 const mockMsrZendeskTicket = {
   id: 123412341234 as unknown as bigint,
+  encoded_id: "ABC-123",
 } as ZendeskTicket;
 const baseSupportRequestPayload = {
   msrId: 123 as unknown as bigint,
@@ -195,7 +197,7 @@ describe("createAndUpdateZendeskMatchTickets", () => {
       expect(sendEmailToMsrMock).toHaveBeenCalledWith(
         {
           ...mockMsrFromZendesk,
-          zendeskTicketId: legalSupportRequest["zendeskTicketId"],
+          encoded_id: "ABC-123",
         },
         mockVolunteerFromDB,
         TRANSACTIONAL_EMAIL_IDS["legal"]["msr"]
@@ -210,7 +212,7 @@ describe("createAndUpdateZendeskMatchTickets", () => {
       expect(sendEmailToVolunteerMock).toHaveBeenCalledWith(
         {
           ...mockVolunteerFromDB,
-          zendeskTicketId: mockVolunteerZendeskTicket["id"],
+          encoded_id: "EFG-456",
         },
         mockMsrFromZendesk.name,
         "legal"
@@ -296,7 +298,7 @@ describe("createAndUpdateZendeskMatchTickets", () => {
       expect(sendEmailToMsrMock).toHaveBeenCalledWith(
         {
           ...mockMsrFromZendesk,
-          zendeskTicketId: baseSupportRequestPayload["zendeskTicketId"],
+          encoded_id: "ABC-123",
         },
         mockVolunteerFromDB,
         TRANSACTIONAL_EMAIL_IDS["psychological"]["msr"]
@@ -311,7 +313,7 @@ describe("createAndUpdateZendeskMatchTickets", () => {
       expect(sendEmailToVolunteerMock).toHaveBeenCalledWith(
         {
           ...mockVolunteerFromDB,
-          zendeskTicketId: mockVolunteerZendeskTicket["id"],
+          encoded_id: "EFG-456",
         },
         mockMsrFromZendesk.name,
         "psychological"

--- a/src/match/__tests__/directToPublicService.spec.ts
+++ b/src/match/__tests__/directToPublicService.spec.ts
@@ -25,6 +25,7 @@ describe("directToPublicService", () => {
     } as SupportRequests;
     const mockMsrZendeskTicket = {
       id: 123412341234 as unknown as bigint,
+      encoded_id: "ABC-123",
     } as ZendeskTicket;
     const mockMsrZendeskUser = {
       name: "Teste MSR",
@@ -105,7 +106,7 @@ describe("directToPublicService", () => {
       1,
       "test@email.com",
       "Teste MSR",
-      "123123123"
+      "ABC-123"
     );
   });
 });

--- a/src/match/__tests__/directToQueue.spec.ts
+++ b/src/match/__tests__/directToQueue.spec.ts
@@ -22,6 +22,7 @@ describe("directToQueue", () => {
     } as SupportRequests;
     const mockMsrZendeskTicket = {
       id: 123412341234 as unknown as bigint,
+      encoded_id: "ABC-123",
     } as ZendeskTicket;
     const mockMsrZendeskUser = {
       name: "Teste MSR",
@@ -102,7 +103,7 @@ describe("directToQueue", () => {
       1,
       "test@email.com",
       "Teste MSR",
-      "123123123"
+      "ABC-123"
     );
   });
 });

--- a/src/match/__tests__/directToSocialWorker.spec.ts
+++ b/src/match/__tests__/directToSocialWorker.spec.ts
@@ -26,6 +26,7 @@ describe("directToSocialWorker", () => {
     } as SupportRequests;
     const mockMsrZendeskTicket = {
       id: 123412341234 as unknown as bigint,
+      encoded_id: "ABC-123",
     } as ZendeskTicket;
     const mockMsrZendeskUser = {
       name: "Teste MSR Social Worker",
@@ -106,7 +107,7 @@ describe("directToSocialWorker", () => {
       1,
       "test-social-worker@email.com",
       "Teste MSR Social Worker",
-      "123123123"
+      "ABC-123"
     );
   });
 });

--- a/src/match/createAndUpdateZendeskMatchTickets.ts
+++ b/src/match/createAndUpdateZendeskMatchTickets.ts
@@ -203,7 +203,7 @@ export default async function createAndUpdateZendeskMatchTickets(
   await sendEmailToMsr(
     {
       ...msr,
-      encoded_id: msrZendeskTicket?.encoded_id.toString() || "",
+      encoded_id: msrZendeskTicket?.encoded_id || "",
     },
     volunteer,
     transactionalId
@@ -212,7 +212,7 @@ export default async function createAndUpdateZendeskMatchTickets(
   await sendEmailToVolunteer(
     {
       ...volunteer,
-      encoded_id: volunteerZendeskTicket.encoded_id,
+      encoded_id: volunteerZendeskTicket.encoded_id || "",
     },
     msr.name,
     supportRequest.supportType

--- a/src/match/createAndUpdateZendeskMatchTickets.ts
+++ b/src/match/createAndUpdateZendeskMatchTickets.ts
@@ -203,7 +203,9 @@ export default async function createAndUpdateZendeskMatchTickets(
   await sendEmailToMsr(
     {
       ...msr,
-      encoded_id: msrZendeskTicket?.encoded_id || "",
+      encoded_id: msrZendeskTicket?.encoded_id
+        ? msrZendeskTicket?.encoded_id
+        : "",
     },
     volunteer,
     transactionalId
@@ -212,7 +214,9 @@ export default async function createAndUpdateZendeskMatchTickets(
   await sendEmailToVolunteer(
     {
       ...volunteer,
-      encoded_id: volunteerZendeskTicket.encoded_id || "",
+      encoded_id: volunteerZendeskTicket?.encoded_id
+        ? volunteerZendeskTicket?.encoded_id
+        : "",
     },
     msr.name,
     supportRequest.supportType

--- a/src/match/directToPublicService.ts
+++ b/src/match/directToPublicService.ts
@@ -77,7 +77,7 @@ export default async function directToPublicService(
   await sendEmailPublicService(
     zendeskUser.email,
     zendeskUser.name,
-    updatedTicket?.encoded_id.toString() || ""
+    updatedTicket?.encoded_id || ""
   );
 
   return updateSupportRequest;

--- a/src/match/directToPublicService.ts
+++ b/src/match/directToPublicService.ts
@@ -38,7 +38,7 @@ async function updateMsrZendeskTicketWithPublicService(
 
   const zendeskTicket = await updateTicket(ticket);
 
-  return zendeskTicket ? zendeskTicket.id : null;
+  return zendeskTicket ? zendeskTicket : null;
 }
 
 export type PublicService = Pick<SupportRequest, "zendeskTicketId" | "msrId">;
@@ -70,14 +70,14 @@ export default async function directToPublicService(
     throw new Error("Couldn't fetch msr from zendesk");
   }
 
-  await updateMsrZendeskTicketWithPublicService(
+  const updatedTicket = await updateMsrZendeskTicketWithPublicService(
     updateSupportRequest.zendeskTicketId
   );
 
   await sendEmailPublicService(
     zendeskUser.email,
     zendeskUser.name,
-    updateSupportRequest.zendeskTicketId.toString()
+    updatedTicket?.encoded_id.toString() || ""
   );
 
   return updateSupportRequest;

--- a/src/match/directToPublicService.ts
+++ b/src/match/directToPublicService.ts
@@ -77,7 +77,7 @@ export default async function directToPublicService(
   await sendEmailPublicService(
     zendeskUser.email,
     zendeskUser.name,
-    updatedTicket?.encoded_id || ""
+    updatedTicket?.encoded_id ? updatedTicket?.encoded_id : ""
   );
 
   return updateSupportRequest;

--- a/src/match/directToQueue.ts
+++ b/src/match/directToQueue.ts
@@ -38,7 +38,7 @@ async function updateMsrZendeskTicketWithQueue(
 
   const zendeskTicket = await updateTicket(ticket);
 
-  return zendeskTicket ? zendeskTicket.id : null;
+  return zendeskTicket ? zendeskTicket : null;
 }
 
 export type Queue = Pick<SupportRequest, "zendeskTicketId" | "msrId">;
@@ -70,12 +70,14 @@ export default async function directToQueue(
     throw new Error("Couldn't fetch msr from zendesk");
   }
 
-  await updateMsrZendeskTicketWithQueue(updateSupportRequest.zendeskTicketId);
+  const updatedTicket = await updateMsrZendeskTicketWithQueue(
+    updateSupportRequest.zendeskTicketId
+  );
 
   await sendEmailQueue(
     zendeskUser.email,
     zendeskUser.name,
-    updateSupportRequest.zendeskTicketId.toString()
+    updatedTicket?.encoded_id.toString() || ""
   );
 
   return updateSupportRequest;

--- a/src/match/directToQueue.ts
+++ b/src/match/directToQueue.ts
@@ -77,7 +77,7 @@ export default async function directToQueue(
   await sendEmailQueue(
     zendeskUser.email,
     zendeskUser.name,
-    updatedTicket?.encoded_id || ""
+    updatedTicket?.encoded_id ? updatedTicket?.encoded_id : ""
   );
 
   return updateSupportRequest;

--- a/src/match/directToQueue.ts
+++ b/src/match/directToQueue.ts
@@ -77,7 +77,7 @@ export default async function directToQueue(
   await sendEmailQueue(
     zendeskUser.email,
     zendeskUser.name,
-    updatedTicket?.encoded_id.toString() || ""
+    updatedTicket?.encoded_id || ""
   );
 
   return updateSupportRequest;

--- a/src/match/directToSocialWorker.ts
+++ b/src/match/directToSocialWorker.ts
@@ -78,7 +78,7 @@ export default async function directToSocialWorker(
   await sendEmailSocialWorker(
     zendeskUser.email,
     zendeskUser.name,
-    updatedTicket?.encoded_id.toString() || ""
+    updatedTicket?.encoded_id || ""
   );
 
   return updateSupportRequest;

--- a/src/match/directToSocialWorker.ts
+++ b/src/match/directToSocialWorker.ts
@@ -78,7 +78,7 @@ export default async function directToSocialWorker(
   await sendEmailSocialWorker(
     zendeskUser.email,
     zendeskUser.name,
-    updatedTicket?.encoded_id || ""
+    updatedTicket?.encoded_id ? updatedTicket?.encoded_id : ""
   );
 
   return updateSupportRequest;

--- a/src/match/directToSocialWorker.ts
+++ b/src/match/directToSocialWorker.ts
@@ -39,7 +39,7 @@ async function updateMsrZendeskTicketWithSocialworker(
 
   const zendeskTicket = await updateTicket(ticket);
 
-  return zendeskTicket ? zendeskTicket.id : null;
+  return zendeskTicket ? zendeskTicket : null;
 }
 
 export type SocialWorker = Pick<SupportRequest, "zendeskTicketId" | "msrId">;
@@ -71,14 +71,14 @@ export default async function directToSocialWorker(
     throw new Error("Couldn't fetch msr from zendesk");
   }
 
-  await updateMsrZendeskTicketWithSocialworker(
+  const updatedTicket = await updateMsrZendeskTicketWithSocialworker(
     updateSupportRequest.zendeskTicketId
   );
 
   await sendEmailSocialWorker(
     zendeskUser.email,
     zendeskUser.name,
-    updateSupportRequest.zendeskTicketId.toString()
+    updatedTicket?.encoded_id.toString() || ""
   );
 
   return updateSupportRequest;

--- a/src/types/Zendesk.ts
+++ b/src/types/Zendesk.ts
@@ -18,13 +18,14 @@ export type UpdateZendeskUser = Partial<Omit<ZendeskUser, "id">> & {
 export type ZendeskTicket = {
   id: bigint;
   requester_id: bigint;
+  encoded_id: string;
 };
 
 export type UpdateZendeskTicket = Partial<Omit<ZendeskTicket, "id">> & {
   id: bigint;
 };
 
-export type CreateZendeskTicket = Omit<ZendeskTicket, "id">;
+export type CreateZendeskTicket = Omit<ZendeskTicket, "id" | "encoded_id">;
 
 export type ZendeskTicketRes = {
   ticket: ZendeskTicket;


### PR DESCRIPTION
Esse PR usa o parâmetro `encoded_id` do ticket do Zendesk para enviar os emails de encaminhamento. Esse parâmetro é utilizado para gerar o replyTo do email e, com isso, a resposta da MSR/Voluntária fica no mesmo ticket (em vez de criar um novo ticket).

Antes, estávamos usando o `ticket_id` para gerar esse replyTo. Mas o Zendesk fez uma atualização e agora precisamos utilizar o `encoded_id`